### PR TITLE
Added missing dependencies 

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ Dependencies
 * zlib for CRC calculation, GZIP compression
 * Snappy for Snappy compression
 * Google Test for unit tests
+* autoconf
+* libtool
 * (optional) lcov/gcov for unit test coverage reporting
 * (optional) doxygen for C/C++ API documentation
 


### PR DESCRIPTION
I was following your installation guide on your readme file, and encountered errors while running autogen.sh. 

*\* Note: I'm running Ubuntu 12.04.

To resolve this, you'll need to install autoconf and libtool
- sudo apt-get install autoconf
- sudo apt-get install libtool
