### PR TITLE
using correct datatype: size_t is size_t and should not be something else

### DIFF
--- a/lib/src/Packet.cc
+++ b/lib/src/Packet.cc
@@ -270,7 +270,7 @@ int Packet::writeCompressedBytes(unsigned char* bytes, int numBytes, Compression
 
   if (codec == COMPRESSION_SNAPPY)
   {
-    unsigned long compressionBufferSize = snappy::MaxCompressedLength(numBytes);
+    size_t compressionBufferSize = snappy::MaxCompressedLength(numBytes);
     unsigned char* compressionBuffer = new unsigned char[compressionBufferSize];
     snappy::RawCompress((const char *)bytes, numBytes, (char *)compressionBuffer, &compressionBufferSize);
     this->writeBytes(compressionBuffer, (long)compressionBufferSize);


### PR DESCRIPTION
size_t is a type depending on your architecture.
for 32Bit it is unsigned int. (32Bits)
for 64Bit it is (for most of the systems) unsigned long. (64Bits)

however it should be size_t if the return is size_t and we pass it again in size_t type.
